### PR TITLE
add data access role

### DIFF
--- a/.env
+++ b/.env
@@ -1,0 +1,6 @@
+# name of service that will have register scope
+stac_register_service_id="MAAP-workflows"
+# stage
+stage="dev"
+# owner
+owner="Emile Tenezakis"

--- a/README.md
+++ b/README.md
@@ -1,8 +1,8 @@
 # MAAP Auth System
 
-This codebase represents the Cognito-based authentication system used for the MAAP STAC infrastructure.
+This codebase stores the IaC for authentication and common IAM roles used for the MAAP STAC infrastructure.
 
-Note: This is for setting up the user pools and managing applications, it is _not_ for managing users. Managing users should be instead done via AWS
+Note : Managing cognito users should be done via the console.
 
 ## Deploying
 
@@ -16,7 +16,9 @@ Run :
 - `cdk synth --all`
 - `cdk deploy --all`
 
-## Running the example service client
+## Cognito resources
+
+### Running the example service client
 
 This example script provides you with credentials based on service authentication.
 
@@ -25,18 +27,18 @@ python3 -m pip install -r requirements.txt
 python3 scripts/service-auth-example.py
 ```
 
-## Expanding
+### Expanding
 
 The codebase intends to be expandable to meet MAAP's needs as the project grows. Currently, the stack exposes two methods to facilitate customization.
 
-### Adding a Resource Server
+#### Adding a Resource Server
 
 A resource server is a service that is to be protected by auth.
 
-### `stack.add_programmatic_client(client_identifier)`
+#### `stack.add_programmatic_client(client_identifier)`
 
 The intention of this endpoint is to create a client for a user to make use of when authenticating in a programmatic environment (e.g. script, notebook).
 
-### `stack.add_service_client(client_identifier)`
+#### `stack.add_service_client(client_identifier)`
 
 Add a service that will be authenticating with the MAAP system. This utilizes the [`client_credentials` flow](https://www.oauth.com/oauth2-servers/access-tokens/client-credentials/), meaning that the credentials represent a _service_ rather than any particular _user_.

--- a/app.py
+++ b/app.py
@@ -48,7 +48,6 @@ auth_stac.add_service_client(
 # auth_stac.add_user_client("MAAP-sdk")
 
 
-
 # create roles stack
 auth_stac = RolesStack(
     app,
@@ -58,9 +57,7 @@ auth_stac = RolesStack(
         "Owner": config.owner,
         "Client": "NASA",
         "Stack": config.stage,
-    },
-    data_pipeline_role_name=config.data_pipeline_role_name,
-    stac_ingestor_role_name=config.stac_ingestor_role_name
+    }
 )
 
 app.synth()

--- a/config.py
+++ b/config.py
@@ -40,3 +40,18 @@ class Config(pydantic.BaseSettings):
         ),
         default_factory=getuser,
     )
+    data_pipeline_role_name: str = pydantic.Field(
+        description=" ".join(
+            [
+                "name of the role that will be used by the data pipeline",
+            ]
+        ),
+        default_factory=getuser,
+    )
+    stac_ingestor_role_name: str = pydantic.Field(
+        description=" ".join(
+            [
+                "name of the role that will be used by the stac ingestion service",
+            ]
+        ),
+    )

--- a/config.py
+++ b/config.py
@@ -14,14 +14,6 @@ class Config(pydantic.BaseSettings):
         ),
         default_factory=getuser,
     )
-    stack_base: str = pydantic.Field(
-        description=" ".join(
-            [
-                "prefix of the stack name.",
-            ]
-        ),
-        default_factory=getuser,
-    )
     stac_register_service_id: str = pydantic.Field(
         description=" ".join(
             [

--- a/config.py
+++ b/config.py
@@ -40,18 +40,3 @@ class Config(pydantic.BaseSettings):
         ),
         default_factory=getuser,
     )
-    data_pipeline_role_name: str = pydantic.Field(
-        description=" ".join(
-            [
-                "name of the role that will be used by the data pipeline",
-            ]
-        ),
-        default_factory=getuser,
-    )
-    stac_ingestor_role_name: str = pydantic.Field(
-        description=" ".join(
-            [
-                "name of the role that will be used by the stac ingestion service",
-            ]
-        ),
-    )

--- a/infra/AuthStack.py
+++ b/infra/AuthStack.py
@@ -130,7 +130,7 @@ class AuthStack(Stack):
 
         domain = userpool.add_domain(
             "cognito-domain",
-            cognito_domain=cognito.CognitoDomainOptions(domain_prefix=stack_name),
+            cognito_domain=cognito.CognitoDomainOptions(domain_prefix=stack_name.lower()),
         )
 
         CfnOutput(

--- a/infra/RolesStack.py
+++ b/infra/RolesStack.py
@@ -1,0 +1,75 @@
+from typing import Optional
+
+
+from aws_cdk import (
+    aws_iam as iam,
+    aws_s3 as s3,
+    CfnOutput,
+    Stack,
+)
+from constructs import Construct
+
+class RolesStack(Stack):
+    def __init__(self, scope: Construct, construct_id: str, data_pipeline_role_name: str, stac_ingestor_role_name: str, **kwargs) -> None:
+        super().__init__(scope, construct_id, **kwargs)
+        
+        self.create_data_access_role(construct_id=construct_id, data_pipeline_role_name=data_pipeline_role_name, stac_ingestor_role_name=stac_ingestor_role_name)
+
+        # export a cloud formation output with the data access role name and arn
+        CfnOutput(
+            self,
+            "data access role name",
+            export_name=f"data-access-role-name-{self.stack_name}",
+            value=self.data_access_role.role_name
+        )
+            
+    def create_data_access_role(
+        self, construct_id: str, data_pipeline_role_name: str, stac_ingestor_role_name: str
+    ):
+        """
+        Creates data access role, attaches inline policy to allow access to s3 buckets, and grants assume role to data pipeline and stac ingestor roles
+        """
+        
+        role_assume = iam.CompositePrincipal(iam.ServicePrincipal("lambda.amazonaws.com"))
+        
+        role = iam.Role(
+            self,
+            f"{construct_id}-data-access-role",
+            role_name=f"{construct_id}-data-access-role",
+            assumed_by=role_assume,
+        )
+        
+        buckets = [
+                "nasa-maap-data-store",
+                "maap-user-shared-data",
+                "maap-ops-workspace",
+                "maap-data-store-test",
+                "nasa-maap-data-store/*",
+                "maap-user-shared-data/*",
+                "maap-ops-workspace/*",
+                "maap-data-store-test/*"
+            ]
+        
+        role.attach_inline_policy(
+            iam.Policy(
+                self,
+                "Policy",
+                statements=[
+                    iam.PolicyStatement(
+                        effect=iam.Effect.ALLOW,
+                        actions=["s3:PutObject*", "s3:ListBucket*", "s3:GetObject*"],
+                        resources=[f"arn:aws:s3:::{bucket}" for bucket in buckets],
+                    )
+                ],
+            )
+        )
+        
+        data_pipeline_role = iam.Role.from_role_name(self, 'data-pipeline-role', data_pipeline_role_name)
+        
+        stac_ingestor_role = iam.Role.from_role_name(self, 'stac-ingestor-role', stac_ingestor_role_name)
+        
+        role.grant_assume_role(data_pipeline_role)
+        role.grant_assume_role(stac_ingestor_role)
+        
+        self.data_access_role = role
+        

--- a/infra/RolesStack.py
+++ b/infra/RolesStack.py
@@ -51,7 +51,7 @@ class RolesStack(Stack):
         role.attach_inline_policy(
             iam.Policy(
                 self,
-                "Policy",
+                "bucket-access-policy",
                 statements=[
                     iam.PolicyStatement(
                         effect=iam.Effect.ALLOW,

--- a/infra/RolesStack.py
+++ b/infra/RolesStack.py
@@ -55,7 +55,7 @@ class RolesStack(Stack):
                 statements=[
                     iam.PolicyStatement(
                         effect=iam.Effect.ALLOW,
-                        actions=["s3:PutObject*", "s3:ListBucket*", "s3:GetObject*"],
+                        actions=["s3:ListBucket*", "s3:GetObject*"],
                         resources=[f"arn:aws:s3:::{bucket}" for bucket in buckets],
                     )
                 ],

--- a/scripts/service-auth-example.py
+++ b/scripts/service-auth-example.py
@@ -48,13 +48,12 @@ class Creds(pydantic.BaseModel):
 
 
 class Settings(pydantic.BaseSettings):
-    stack_base: str
     stage: str
     stac_register_service_id: str
 
     @property
     def stack_name(self) -> str:
-        return f"{self.stack_base}-{self.stage}"
+        return f"MAAP-STAC-auth-{self.stage}"
 
     def get_cognito_service_details(self) -> "CognitoClientDetails":
         client = boto3.client("secretsmanager")


### PR DESCRIPTION
Adds a second stack on top of the initial one. The former is called 'auth stack', referring to the cognito resources. The new one is called 'roles stack', referring to IAM roles commonly used across the infra components, that we want to create here. 

For now we're only creating a 'data access role', which is a role commonly used by other stacks to access S3 buckets. In order to allow roles in other stacks to assume this data access role, I am making use of this python CDK pattern : 


```
        role.assume_role_policy.add_statements(
            iam.PolicyStatement(
                effect=iam.Effect.ALLOW,
                principals=[iam.AnyPrincipal()],
                actions=["sts:AssumeRole"],
                conditions={
                    "StringLike": {
                        "aws:PrincipalArn": [
                            f"arn:aws:iam::{account_id}:role/{ROLE_PATTERN}",
                        ]
                    }
                }
            )
        )
```

where `ROLE_PATTERN` can contain `*` in order to restrict permissions but still allow other roles with predictable names in the same account to assume this data access role. The benefit of this pattern is that we can add this trust relationship without having these 'assumer' roles exist already. This solves one of the problems raised here https://github.com/NASA-IMPACT/active-maap-sprint/issues/515. 

On the console AWS complains that I am adding as `principals` `iam.AnyPrincipal()`, but I did confirm that this does NOT allow roles that do not match the pattern to assume this role, so I think we're good. 

For now, there are only two role patterns that are allowed and are hard coded in the `RoleStack.py` : 

```
DATA_PIPELINE_LAMBDA_EXECUTION_ROLE_PATTERN = "maap-data-pipelines-*-datapipelinelambdarole*"
STAC_INGESTOR_EXECUTION_ROLE_PATTERN = 'MAAP-STAC-*-pgSTAC-stacingestorexecutionrole*'
```

The name of a role even when it's automatically chosen by AWS follows this pattern `{stack_name}-{role-id}`. 

In the future, if we change the names of the stacks, or the role ids in their respective stacks, we should change these.  