### PR TITLE
broaden trust relationship

### DIFF
--- a/infra/RolesStack.py
+++ b/infra/RolesStack.py
@@ -7,7 +7,7 @@ import boto3
 from constructs import Construct
 
 DATA_PIPELINE_LAMBDA_EXECUTION_ROLE_PATTERN = "maap-data-pipelines-*-datapipelinelambdarole*"
-STAC_INGESTOR_EXECUTION_ROLE_PATTERN = 'MAAP-STAC-*-pgSTAC-stacingestorexecutionrole*'
+STAC_INGESTOR_EXECUTION_ROLE_PATTERN = 'stacingestor'
 
 class RolesStack(Stack):
     def __init__(self, scope: Construct, construct_id: str, **kwargs) -> None:


### PR DESCRIPTION
Previously, roles with this pattern 'MAAP-STAC-*-pgSTAC-stacingestorexecutionrole*' were granted permission to assume the data access role. Now it's all roles with the 'stacingestor' pattern. The previous one was too restrictive -- when names are too long AWS shortens them automatically and the truncation is quite unpredictable. 