### PR TITLE
feat: add kms key to auth secret

### DIFF
--- a/.env
+++ b/.env
@@ -1,6 +1,11 @@
 # name of service that will have register scope
 stac_register_service_id="MAAP-workflows"
+
 # stage
 stage="dev"
+
 # owner
 owner="Jamison French"
+
+# ADE IAM role
+ade_iam_role="arn:aws:iam::884094767067:role/MAAP-ADE-K8S"

--- a/.env
+++ b/.env
@@ -3,4 +3,4 @@ stac_register_service_id="MAAP-workflows"
 # stage
 stage="dev"
 # owner
-owner="Emile Tenezakis"
+owner="Jamison French"

--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,14 @@
+*.js
+!jest.config.js
+*.d.ts
+node_modules
+
+.pyc
+__pycache__
+.venv
+
+.envrc
+
+# CDK asset staging directory
+.cdk.staging
+cdk.out

--- a/app.py
+++ b/app.py
@@ -13,6 +13,7 @@ app = cdk.App()
 auth_stac = AuthStack(
     app,
     f"MAAP-STAC-auth-{config.stage}",
+    ade_iam_role=config.ade_iam_role,
     tags={
         "Project": "MAAP",
         "Owner": config.owner,

--- a/config.py
+++ b/config.py
@@ -32,3 +32,11 @@ class Config(pydantic.BaseSettings):
         ),
         default_factory=getuser,
     )
+    ade_iam_role: str = pydantic.Field(
+        description=" ".join(
+            [
+                "ARN of the ADE IAM role allowed to retrieve secrets",
+                "Example: arn:aws:iam::123456789012:role/MyRole",
+            ]
+        ),
+    )

--- a/infra/AuthStack.py
+++ b/infra/AuthStack.py
@@ -24,8 +24,9 @@ class BucketPermissions(str, Enum):
 
 
 class AuthStack(Stack):
-    def __init__(self, scope: Construct, construct_id: str, **kwargs) -> None:
+    def __init__(self, scope: Construct, construct_id: str, ade_iam_role: str, **kwargs) -> None:
         super().__init__(scope, construct_id, **kwargs)
+        self.ade_iam_role = ade_iam_role
         self.userpool = self._create_userpool()
         self.domain = self._add_domain(self.userpool)
         auth_provider_client = self.add_user_client(
@@ -223,7 +224,7 @@ class AuthStack(Stack):
                     actions=["kms:Decrypt", "kms:DescribeKey"],
                     effect=iam.Effect.ALLOW,
                     resources=["*"],
-                    principals=[iam.ArnPrincipal("arn:aws:iam::884094767067:role/MAAP-ADE-K8S")],
+                    principals=[iam.ArnPrincipal(self.ade_iam_role)],
                 )
             ]
         )
@@ -281,7 +282,7 @@ class AuthStack(Stack):
                 actions=["secretsmanager:GetSecretValue"],
                 effect=iam.Effect.ALLOW,
                 resources=[secret.secret_arn],
-                principals=[iam.ArnPrincipal("arn:aws:iam::884094767067:role/MAAP-ADE-K8S")],
+                principals=[iam.ArnPrincipal(self.ade_iam_role)],
             )
         )
 

--- a/infra/AuthStack.py
+++ b/infra/AuthStack.py
@@ -223,7 +223,7 @@ class AuthStack(Stack):
                     actions=["kms:Decrypt", "kms:DescribeKey"],
                     effect=iam.Effect.ALLOW,
                     resources=["*"],
-                    principals=[iam.ArnPrincipal(f"arn:aws:iam::{Stack.of(self).account}:role/MAAP-ADE-K8S")],
+                    principals=[iam.ArnPrincipal("arn:aws:iam::884094767067:role/MAAP-ADE-K8S")],
                 )
             ]
         )

--- a/infra/AuthStack.py
+++ b/infra/AuthStack.py
@@ -276,6 +276,14 @@ class AuthStack(Stack):
             secret_string_value=SecretValue.unsafe_plain_text(json.dumps(secret_dict)),
             replica_regions=[{"region": region} for region in replica_regions or []],
         )
+        secret.add_to_resource_policy(
+            iam.PolicyStatement(
+                actions=["secretsmanager:GetSecretValue"],
+                effect=iam.Effect.ALLOW,
+                resources=[secret.secret_arn],
+                principals=[iam.ArnPrincipal("arn:aws:iam::884094767067:role/MAAP-ADE-K8S")],
+            )
+        )
 
         CfnOutput(
             self,

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-aws-cdk-lib==2.35.0
+aws-cdk-lib==2.168.0
 aws_cdk.aws_cognito_identitypool_alpha==2.35.0a0
 constructs>=10.0.0,<11.0.0
 pydantic==1.9.1


### PR DESCRIPTION
## Description
- created policy document for KMS key (similar to key aws/secretsmanager)
- adds custom KMS key to secret
  - enables secret to be read across accounts